### PR TITLE
fix datetime encode/decode

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -441,7 +441,7 @@ class TestKv(Test):
                 'list_with_floats': [10.5, 20.5, 30.5],
                 'array_with_ints': _get_int_array(),
                 'array_with_floats': _get_float_array(),
-                'now': datetime.datetime.utcnow()
+                'now': datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
             }
         }
 

--- a/tests/test_client_aio.py
+++ b/tests/test_client_aio.py
@@ -408,7 +408,7 @@ class TestKv(Test):
                 'list_with_floats': [10.5, 20.5, 30.5],
                 'array_with_ints': _get_int_array(),
                 'array_with_floats': _get_float_array(),
-                'now': datetime.datetime.utcnow()
+                'now': datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
             }
         }
 

--- a/tests/test_client_deprecated.py
+++ b/tests/test_client_deprecated.py
@@ -442,7 +442,7 @@ class TestEmd(Test):
                 'list_with_floats': [10.5, 20.5, 30.5],
                 'array_with_ints': _get_int_array(),
                 'array_with_floats': _get_float_array(),
-                'now': datetime.datetime.utcnow()
+                'now': datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
             }
         }
 

--- a/v3io/dataplane/kv_timestamp.py
+++ b/v3io/dataplane/kv_timestamp.py
@@ -6,7 +6,7 @@ BASE_DATETIME = datetime.datetime(1970, 1, 1)
 
 
 def _get_timestamp_from_datetime_py3(dt):
-    return dt.replace(tzinfo=datetime.timezone.utc).timestamp()
+    return dt.astimezone(datetime.timezone.utc).timestamp()
 
 
 def _get_timestamp_from_datetime_py2(dt):
@@ -35,4 +35,4 @@ def decode(encoded_dt):
 
     timestamp = int(seconds_str) + (int(nanoseconds_str) / 10e9)
 
-    return datetime.datetime.utcfromtimestamp(timestamp)
+    return datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc)


### PR DESCRIPTION
Issues:
* The encode assumed that the given datetime is in UTC, rather then **convert** it to UTC
* The decode didn't return a UTC timezoned time. which caused bugs when writing a timestamp from nginx, and reading via v3io-py the time object returned was incorrect.