### PR TITLE
Fixed limit in kv_cursor

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -518,15 +518,6 @@ class TestKv(Test):
 
         self.assertEqual(4, len(total_items))
 
-        # with limit = 0
-        received_items = self._client.kv.new_cursor(container=self._container,
-                                                    table_path=self._path,
-                                                    attribute_names=['age', 'feature'],
-                                                    filter_expression='age > 15',
-                                                    limit=0).all()
-
-        self.assertEqual(0, len(received_items))
-
         received_items = self._client.kv.new_cursor(container=self._container,
                                                     table_path=self._path,
                                                     attribute_names=['age', 'feature'],
@@ -551,6 +542,22 @@ class TestKv(Test):
                                        attribute_names=['age'])
 
         self.assertEqual(10, response.output.item['age'])
+
+    def test_limit(self):
+        for idx in range(100):
+            self._client.kv.put(container=self._container,
+                                table_path=self._path,
+                                key=f'key-{idx}',
+                                attributes={
+                                    'attr': idx,
+                                })
+
+        # limit using all()
+        received_items = self._client.kv.new_cursor(container=self._container,
+                                                    table_path=self._path,
+                                                    limit=30).all()
+
+        self.assertEqual(len(received_items), 30)
 
     def test_batch(self):
         items = {
@@ -787,7 +794,6 @@ class TestCustomTransport(unittest.TestCase):
         #
 
         def _verify_object_get(request):
-
             # verify some stuff from the request
             self.assertEqual(request.container, container_name)
             self.assertEqual(request.path, os.path.join(os.sep, container_name, 'some/path'))
@@ -797,7 +803,6 @@ class TestCustomTransport(unittest.TestCase):
                                            body='some body')
 
         def _verify_kv_get(request):
-
             # verify some stuff from the request
             self.assertEqual(request.container, container_name)
             self.assertEqual(request.path, os.path.join(os.sep, container_name, 'some/table/path/some_item_key'))

--- a/tests/test_client_aio.py
+++ b/tests/test_client_aio.py
@@ -482,15 +482,6 @@ class TestKv(Test):
 
         self.assertEqual(4, len(total_items))
 
-        # with limit = 0
-        received_items = await self._client.kv.new_cursor(container=self._container,
-                                                          table_path=self._path,
-                                                          attribute_names=['age', 'feature'],
-                                                          filter_expression='age > 15',
-                                                          limit=0).all()
-
-        self.assertEqual(0, len(received_items))
-
         received_items = await self._client.kv.new_cursor(container=self._container,
                                                           table_path=self._path,
                                                           attribute_names=['age', 'feature'],
@@ -515,6 +506,23 @@ class TestKv(Test):
                                              attribute_names=['age'])
 
         self.assertEqual(10, response.output.item['age'])
+
+    async def test_limit(self):
+
+        for idx in range(100):
+            await self._client.kv.put(container=self._container,
+                                      table_path=self._path,
+                                      key=f'key-{idx}',
+                                      attributes={
+                                          'attr': idx,
+                                      })
+
+        # limit using all()
+        received_items = await self._client.kv.new_cursor(container=self._container,
+                                                          table_path=self._path,
+                                                          limit=30).all()
+
+        self.assertEqual(len(received_items), 30)
 
     async def _delete_items(self, path, items):
 

--- a/v3io/dataplane/kv_cursor.py
+++ b/v3io/dataplane/kv_cursor.py
@@ -22,6 +22,7 @@ class Cursor(object):
         self._current_items = None
         self._current_item = None
         self._current_item_index = 0
+        self._total_items_read = 0
 
         # get items params
         self.raise_for_status = raise_for_status
@@ -37,12 +38,27 @@ class Cursor(object):
         self.sort_key_range_end = sort_key_range_end
 
     def next_item(self):
+        calculated_limit = self.limit
+
+        # check if we already reached the limit we were asked for
+        if self.limit is not None:
+
+            # if we already passed the limit, stop here
+            if self._total_items_read >= self.limit:
+                return None
+
+            # don't ask for more items than we'll read
+            calculated_limit -= self._total_items_read
+
+        # if we already have the item in memory (from the previous scan), return it
         if self._current_item_index < len(self._current_items or []):
             self._current_item = self._current_items[self._current_item_index]
             self._current_item_index += 1
+            self._total_items_read += 1
 
             return self._current_item
 
+        # if we had a response which was signaled as last, or we didn't get a responsereturn none
         if self._current_response and (self._current_response.output.last or len(self._current_items) == 0):
             return None
 
@@ -58,7 +74,7 @@ class Cursor(object):
                                                        self.filter_expression,
                                                        self.marker,
                                                        self.sharding_key,
-                                                       self.limit,
+                                                       calculated_limit,
                                                        self.segment,
                                                        self.total_segments,
                                                        self.sort_key_range_start,


### PR DESCRIPTION
Previous behavior:
Passing limit to kv_cursor would pass the limit value to the underlying scan. If several scans were executed until "last" item was received, the same initial limit would be passed each time to the request. Therefore, no limit was actually imposed.

Current behavior:
The underlying scan receives "limit - total_items_received". Therefore the scans should never request more than "limit" items 