### PR TITLE
Add error flow tests

### DIFF
--- a/tests/test_client_errors.py
+++ b/tests/test_client_errors.py
@@ -1,0 +1,101 @@
+import itertools
+
+import pytest
+
+import v3io.dataplane.client
+import v3io.dataplane.transport.httpclient
+
+
+class MockResponse:
+    def __init__(self, code=None, headers=None):
+        self.code = code or 200
+        self.headers = headers or {}
+
+    def read(self):
+        return "mock response"
+
+    def getheaders(self):
+        return self.headers
+
+
+class ATestException(Exception):
+    pass
+
+
+class MockConnection:
+    def __init__(self, fail_request_after=None, fail_getresponse_after=None):
+        self.times_closed = 0
+        self.times_request = 0
+        self.times_got_response = 0
+
+        self.fail_request_after = fail_request_after
+        self.fail_getresponse_after = fail_getresponse_after
+
+    def request(self, method, path, body, headers):
+        self.times_request += 1
+        if self.fail_request_after is not None and self.times_request > self.fail_request_after:
+            raise ATestException(f"Failing request number {self.times_request}")
+
+    def getresponse(self):
+        self.times_got_response += 1
+        if self.fail_getresponse_after is not None and self.times_got_response > self.fail_getresponse_after:
+            raise ATestException(f"Failing response number {self.times_got_response}")
+        return MockResponse()
+
+    def raise_for_status(self, expected_statuses=None):
+        pass
+
+    def close(self):
+        self.times_closed += 1
+
+
+class MockTransport(v3io.dataplane.transport.httpclient.Transport):
+    def __init__(self, *args, connection_options=None, **kwargs):
+        self.mock_connections = []
+        self.connection_options = connection_options or {}
+        super().__init__(*args, **kwargs)
+
+    def _create_connection(self, host, ssl_context):
+        conn = MockConnection(**self.connection_options)
+        self.mock_connections.append(conn)
+        return conn
+
+
+def test_connection_creation_and_close():
+    client = v3io.dataplane.Client()
+    mock_transport = MockTransport(client._logger)
+    client._transport = mock_transport
+    for _ in range(20):
+        client.get_object("mycontainer", "mypath")
+    assert len(mock_transport.mock_connections) == 8
+    for conn in mock_transport.mock_connections:
+        assert conn.times_closed == 0
+    client.close()
+    assert len(mock_transport.mock_connections) == 8
+    for conn in mock_transport.mock_connections:
+        assert conn.times_closed == 1
+
+
+@pytest.mark.parametrize(["fail_request_after", "fail_getresponse_after"], itertools.permutations(range(3), 2))
+def test_connection_closed_on_error(fail_request_after, fail_getresponse_after):
+    client = v3io.dataplane.Client()
+    connection_options = {
+        "fail_request_after": fail_request_after,
+        "fail_getresponse_after": fail_getresponse_after,
+    }
+    mock_transport = MockTransport(client._logger, connection_options=connection_options)
+    client._transport = mock_transport
+    for _ in range(20):
+        try:
+            client.get_object("mycontainer", "mypath")
+        except ATestException:
+            pass
+    num_connections_still_open = 0
+    for conn in mock_transport.mock_connections:
+        assert conn.times_closed == 0 or conn.times_closed == 1
+        if conn.times_closed == 0:
+            num_connections_still_open += 1
+    assert num_connections_still_open == 8
+    client.close()
+    for conn in mock_transport.mock_connections:
+        assert conn.times_closed == 1


### PR DESCRIPTION
The new tests function as regression tests for #100. Without that change, some tests fails on
```
UnboundLocalError: local variable 'response_body' referenced before assignment
```
and others on
```
        for conn in mock_transport.mock_connections:
>           assert conn.times_closed == 0 or conn.times_closed == 1
E           assert (2 == 0
E             +2
E             -0 or 2 == 1
E             +2
E             -1)
```
(double closing of connections)