### PR TITLE
[Logger] Fix multiple logs

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -149,7 +149,6 @@ class TestStream(Test):
         self.assertFalse(self._stream_exists())
 
     def test_stream(self):
-
         # create a stream w/8 shards
         self._client.stream.create(container=self._container, stream_path=self._path, shard_count=8)
 
@@ -565,7 +564,6 @@ class TestKv(Test):
             self.assertEqual(200, response.status_code)
 
     def _delete_items(self, path, items):
-
         # delete items
         for item_key, _ in future.utils.viewitems(items):
             self._client.kv.delete(container=self._container, table_path=path, key=item_key)
@@ -650,7 +648,6 @@ class TestBatchRaiseForStatus(Test):
         responses = self._client.batch.wait()
 
         for object_idx in range(num_objects):
-
             # inject an error
             if object_idx == err_idx:
                 object_idx = 10
@@ -661,7 +658,6 @@ class TestBatchRaiseForStatus(Test):
 
         # do it again, only this time don't raise
         for object_idx in range(num_objects):
-
             # inject an error
             if object_idx == 1:
                 object_idx = 10
@@ -692,7 +688,6 @@ class TestConnectonErrorRecovery(Test):
 
     @unittest.skip("Manually executed")
     def test_object(self):
-
         for i in range(100):
             body = "iteration {}".format(i)
 

--- a/tests/test_client_aio.py
+++ b/tests/test_client_aio.py
@@ -143,7 +143,6 @@ class TestStream(Test):
         self.assertFalse(await self._stream_exists())
 
     async def test_stream(self):
-
         # create a stream w/8 shards
         await self._client.stream.create(container=self._container, stream_path=self._path, shard_count=8)
 
@@ -499,7 +498,6 @@ class TestKv(Test):
         self.assertEqual(10, response.output.item["age"])
 
     async def test_limit(self):
-
         for idx in range(100):
             await self._client.kv.put(
                 container=self._container,
@@ -518,7 +516,6 @@ class TestKv(Test):
         self.assertEqual(len(received_items), 30)
 
     async def _delete_items(self, path, items):
-
         # delete items
         for item_key, _ in future.utils.viewitems(items):
             await self._client.kv.delete(container=self._container, table_path=path, key=item_key)

--- a/v3io/aio/dataplane/kv_cursor.py
+++ b/v3io/aio/dataplane/kv_cursor.py
@@ -57,7 +57,6 @@ class Cursor(object):
 
         # check if we already reached the limit we were asked for
         if self.limit is not None:
-
             # if we already passed the limit, stop here
             if self._total_items_read >= self.limit:
                 return None

--- a/v3io/aio/dataplane/transport/aiohttp.py
+++ b/v3io/aio/dataplane/transport/aiohttp.py
@@ -39,7 +39,6 @@ class Transport(object):
         await self._connector.close()
 
     async def request(self, container, access_key, raise_for_status, encoder, encoder_args, output=None):
-
         # allocate a request
         request = v3io.dataplane.request.Request(container, access_key, raise_for_status, encoder, encoder_args, output)
 
@@ -55,7 +54,6 @@ class Transport(object):
                 async with self._client_session.request(
                     request.method, self._endpoint + "/" + path, headers=request.headers, data=request.body, ssl=False
                 ) as http_response:
-
                     # get contents
                     contents = await http_response.content.read()
 
@@ -82,7 +80,6 @@ class Transport(object):
 
     @staticmethod
     def _get_endpoint(endpoint):
-
         if endpoint is None:
             endpoint = os.environ.get("V3IO_API")
 

--- a/v3io/dataplane/batch.py
+++ b/v3io/dataplane/batch.py
@@ -100,12 +100,10 @@ class Batch(object):
             raise e
 
     def _wait(self, raise_for_status=None):
-
         responses = []
 
         # while we can send requests - send them
         while self._encoded_requests and len(self._inflight_requests) < self._transport.max_connections:
-
             # send the request
             request = self._transport.send_request(self._encoded_requests.pop(0))
 
@@ -114,7 +112,6 @@ class Batch(object):
 
         # start creating responses
         while self._inflight_requests:
-
             # get an inflight request
             inflight_request = self._inflight_requests.pop(0)
 
@@ -126,7 +123,6 @@ class Batch(object):
 
             # if there's a pending request, send it on the connection that we just read from
             if self._encoded_requests:
-
                 # send the request
                 request = self._transport.send_request(self._encoded_requests.pop(0))
 

--- a/v3io/dataplane/kv_cursor.py
+++ b/v3io/dataplane/kv_cursor.py
@@ -57,7 +57,6 @@ class Cursor(object):
 
         # check if we already reached the limit we were asked for
         if self.limit is not None:
-
             # if we already passed the limit, stop here
             if self._total_items_read >= self.limit:
                 return None

--- a/v3io/dataplane/output.py
+++ b/v3io/dataplane/output.py
@@ -70,7 +70,6 @@ class Container(object):
 
 class GetContainersOutput(Output):
     def __init__(self, root):
-
         # got an error code
         if isinstance(root, dict):
             self.error = root
@@ -90,7 +89,6 @@ class GetContainersOutput(Output):
 
 class ContainerContent(object):
     def __init__(self, child):
-
         # got an error code
         if isinstance(child, dict):
             self.error = child
@@ -115,7 +113,6 @@ class ContainerContent(object):
 
 class ContainerCommonPrefix(object):
     def __init__(self, child):
-
         # got an error code
         if isinstance(child, dict):
             self.error = child
@@ -138,7 +135,6 @@ class ContainerCommonPrefix(object):
 
 class GetContainerContentsOutput(Output):
     def __init__(self, root):
-
         # got an error code
         if isinstance(root, dict):
             self.error = root

--- a/v3io/dataplane/request.py
+++ b/v3io/dataplane/request.py
@@ -415,7 +415,7 @@ def _to_base64(input):
 def _dict_to_typed_attributes(d):
     typed_attributes = {}
 
-    for (key, value) in future.utils.viewitems(d):
+    for key, value in future.utils.viewitems(d):
         attribute_type = type(value)
         type_value = None
 

--- a/v3io/dataplane/transport/abstract.py
+++ b/v3io/dataplane/transport/abstract.py
@@ -37,7 +37,6 @@ class Transport(object):
         pass
 
     def request(self, container, access_key, raise_for_status, transport_actions, encoder, encoder_args, output=None):
-
         # default to sending/receiving
         transport_actions = transport_actions or v3io.dataplane.transport.Actions.send_and_receive
 
@@ -62,7 +61,6 @@ class Transport(object):
 
     @staticmethod
     def _get_endpoint(endpoint):
-
         if endpoint is None:
             endpoint = os.environ.get("V3IO_API")
 

--- a/v3io/dataplane/transport/requests.py
+++ b/v3io/dataplane/transport/requests.py
@@ -33,7 +33,6 @@ class Transport(abstract.Transport):
         self._session.close()
 
     def send_request(self, request):
-
         path = request.encode_path()
 
         # call the encoder to get the response
@@ -45,7 +44,6 @@ class Transport(abstract.Transport):
         return request
 
     def wait_response(self, request, raise_for_status=None, num_retries=1):
-
         # create a response
         response = v3io.dataplane.response.Response(
             request.output,

--- a/v3io/logger/logger.py
+++ b/v3io/logger/logger.py
@@ -33,7 +33,7 @@ class HumanReadableFormatter(logging.Formatter):
 
 class Logger(object):
     def __init__(self, level="DEBUG"):
-        self._logger = logging.getLogger("root")
+        self._logger = logging.getLogger("v3io_py")
         self._logger.setLevel(level)
 
     def set_handler(self, handler_name, file, formatter):

--- a/v3io/logger/logger.py
+++ b/v3io/logger/logger.py
@@ -35,29 +35,23 @@ class Logger(object):
     def __init__(self, level="DEBUG"):
         self._logger = logging.getLogger("root")
         self._logger.setLevel(level)
-        self._handlers = {}
 
     def set_handler(self, handler_name, file, formatter):
-
         # check if there's a handler by this name
-        if handler_name in self._handlers:
-
-            # log that we're removing it
-            self.info_with("Replacing logger output")
-
-            self._logger.removeHandler(self._handlers[handler_name])
+        for handler in self._logger.handlers:
+            if handler.name == handler_name:
+                self._logger.removeHandler(handler)
+                break
 
         # create a stream handler from the file
         stream_handler = logging.StreamHandler(file)
+        stream_handler.name = handler_name
 
         # set the formatter
         stream_handler.setFormatter(formatter)
 
         # add the handler to the logger
         self._logger.addHandler(stream_handler)
-
-        # save as the named output
-        self._handlers[handler_name] = stream_handler
 
     def debug(self, message, *args):
         self._logger.debug(message, *args)


### PR DESCRIPTION
[ML-3978](https://jira.iguazeng.com/browse/ML-3978)

When multiple loggers are created with the same name, remove duplicate handlers so they won't logs the same messages multiple times.

Also - format the code using black.

Porting the fix from https://github.com/mlrun/mlrun/pull/3381 to v3io-py.