### PR TITLE
Fix support for GetItems' `TableName` parameter

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -507,6 +507,18 @@ class TestKv(Test):
         for item in received_items:
             self.assertLess(15, item["age"])
 
+        received_items = self._client.kv.new_cursor(
+            container=self._container,
+            table_path="",
+            table_name=self._path,
+            attribute_names=["age", "feature"],
+            filter_expression="age > 15",
+        ).all()
+
+        self.assertEqual(2, len(received_items))
+        for item in received_items:
+            self.assertLess(15, item["age"])
+
         #
         # Increment age
         #

--- a/tests/test_client_aio.py
+++ b/tests/test_client_aio.py
@@ -484,6 +484,18 @@ class TestKv(Test):
         for item in received_items:
             self.assertLess(15, item["age"])
 
+        received_items = await self._client.kv.new_cursor(
+            container=self._container,
+            table_path="",
+            table_name=self._path,
+            attribute_names=["age", "feature"],
+            filter_expression="age > 15",
+        ).all()
+
+        self.assertEqual(2, len(received_items))
+        for item in received_items:
+            self.assertLess(15, item["age"])
+
         #
         # Increment age
         #

--- a/v3io/aio/dataplane/kv.py
+++ b/v3io/aio/dataplane/kv.py
@@ -232,7 +232,7 @@ class Model(v3io.dataplane.model.Model):
         table_path (Required) : str
             The full path of the table
         table_name (Optional) : str
-            The name the table - using GetItems TableName (if used, table_path must be an empty string). Allows for specifying all tables with '/*'
+            The name of the table. Allows for specifying all tables with '/*'. If used, table_path must be an empty
         access_key (Optional) : str
             The access key with which to authenticate. Defaults to the V3IO_ACCESS_KEY env.
         attribute_names (Optional) : []str or '*'

--- a/v3io/aio/dataplane/kv.py
+++ b/v3io/aio/dataplane/kv.py
@@ -30,6 +30,7 @@ class Model(v3io.dataplane.model.Model):
         self,
         container,
         table_path,
+        table_name=None,
         access_key=None,
         raise_for_status=None,
         attribute_names="*",
@@ -47,6 +48,7 @@ class Model(v3io.dataplane.model.Model):
             container,
             access_key or self._access_key,
             table_path,
+            table_name,
             raise_for_status,
             attribute_names,
             filter_expression,
@@ -205,6 +207,7 @@ class Model(v3io.dataplane.model.Model):
         self,
         container,
         table_path,
+        table_name=None,
         access_key=None,
         raise_for_status=None,
         attribute_names="*",
@@ -228,6 +231,8 @@ class Model(v3io.dataplane.model.Model):
             The container on which to operate.
         table_path (Required) : str
             The full path of the table
+        table_name (Optional) : str
+            The name the table - using GetItems TableName (if used, table_path must be an empty string). Allows for specifying all tables with '/*'
         access_key (Optional) : str
             The access key with which to authenticate. Defaults to the V3IO_ACCESS_KEY env.
         attribute_names (Optional) : []str or '*'

--- a/v3io/aio/dataplane/kv.py
+++ b/v3io/aio/dataplane/kv.py
@@ -233,6 +233,7 @@ class Model(v3io.dataplane.model.Model):
             The full path of the table
         table_name (Optional) : str
             The name of the table. Allows for specifying all tables with '/*'. If used, table_path must be an empty
+            string.
         access_key (Optional) : str
             The access key with which to authenticate. Defaults to the V3IO_ACCESS_KEY env.
         attribute_names (Optional) : []str or '*'

--- a/v3io/aio/dataplane/kv_cursor.py
+++ b/v3io/aio/dataplane/kv_cursor.py
@@ -19,6 +19,7 @@ class Cursor(object):
         container_name,
         access_key,
         table_path,
+        table_name,
         raise_for_status=None,
         attribute_names="*",
         filter_expression=None,
@@ -42,6 +43,7 @@ class Cursor(object):
         # get items params
         self.raise_for_status = raise_for_status
         self.table_path = table_path
+        self.table_name = table_name
         self.attribute_names = attribute_names
         self.filter_expression = filter_expression
         self.marker = marker
@@ -81,6 +83,7 @@ class Cursor(object):
         self._current_response = await self._context.kv.scan(
             self._container_name,
             self.table_path,
+            self.table_name,
             self._access_key,
             self.raise_for_status,
             self.attribute_names,

--- a/v3io/dataplane/kv.py
+++ b/v3io/dataplane/kv.py
@@ -30,6 +30,7 @@ class Model(v3io.dataplane.model.Model):
         self,
         container,
         table_path,
+        table_name=None,
         access_key=None,
         raise_for_status=None,
         attribute_names="*",
@@ -47,6 +48,7 @@ class Model(v3io.dataplane.model.Model):
             container,
             access_key or self._access_key,
             table_path,
+            table_name,
             raise_for_status,
             attribute_names,
             filter_expression,
@@ -228,6 +230,7 @@ class Model(v3io.dataplane.model.Model):
         self,
         container,
         table_path,
+        table_name=None,
         access_key=None,
         raise_for_status=None,
         transport_actions=None,
@@ -252,6 +255,8 @@ class Model(v3io.dataplane.model.Model):
             The container on which to operate.
         table_path (Required) : str
             The full path of the table
+        table_name (Optional) : str
+            The name the table - using GetItems TableName (if used, table_path must be an empty string). Allows for specifying all tables with '/*'
         access_key (Optional) : str
             The access key with which to authenticate. Defaults to the V3IO_ACCESS_KEY env.
         attribute_names (Optional) : []str or '*'

--- a/v3io/dataplane/kv.py
+++ b/v3io/dataplane/kv.py
@@ -256,7 +256,7 @@ class Model(v3io.dataplane.model.Model):
         table_path (Required) : str
             The full path of the table
         table_name (Optional) : str
-            The name the table - using GetItems TableName (if used, table_path must be an empty string). Allows for specifying all tables with '/*'
+            The name of the table. Allows for specifying all tables with '/*'. If used, table_path must be an empty
         access_key (Optional) : str
             The access key with which to authenticate. Defaults to the V3IO_ACCESS_KEY env.
         attribute_names (Optional) : []str or '*'

--- a/v3io/dataplane/kv.py
+++ b/v3io/dataplane/kv.py
@@ -256,7 +256,9 @@ class Model(v3io.dataplane.model.Model):
         table_path (Required) : str
             The full path of the table
         table_name (Optional) : str
+```suggestion
             The name of the table. Allows for specifying all tables with '/*'. If used, table_path must be an empty
+            string.
         access_key (Optional) : str
             The access key with which to authenticate. Defaults to the V3IO_ACCESS_KEY env.
         attribute_names (Optional) : []str or '*'

--- a/v3io/dataplane/kv.py
+++ b/v3io/dataplane/kv.py
@@ -256,7 +256,6 @@ class Model(v3io.dataplane.model.Model):
         table_path (Required) : str
             The full path of the table
         table_name (Optional) : str
-```suggestion
             The name of the table. Allows for specifying all tables with '/*'. If used, table_path must be an empty
             string.
         access_key (Optional) : str

--- a/v3io/dataplane/kv_cursor.py
+++ b/v3io/dataplane/kv_cursor.py
@@ -19,6 +19,7 @@ class Cursor(object):
         container_name,
         access_key,
         table_path,
+        table_name,
         raise_for_status=None,
         attribute_names="*",
         filter_expression=None,
@@ -42,6 +43,7 @@ class Cursor(object):
         # get items params
         self.raise_for_status = raise_for_status
         self.table_path = table_path
+        self.table_name = table_name
         self.attribute_names = attribute_names
         self.filter_expression = filter_expression
         self.marker = marker
@@ -83,6 +85,7 @@ class Cursor(object):
         self._current_response = self._context.kv.scan(
             self._container_name,
             self.table_path,
+            self.table_name,
             self._access_key,
             self.raise_for_status,
             None,


### PR DESCRIPTION
Fix support of table "/*" (all tables) by completing the support for GetItems' TableName