### PR TITLE
[response] Add defaults to http response error

### DIFF
--- a/v3io/dataplane/response.py
+++ b/v3io/dataplane/response.py
@@ -22,7 +22,7 @@ import v3io.dataplane.transport
 class HttpResponseError(Exception):
     """Exception raised on bad http status"""
 
-    def __init__(self, message='', status_code=None):
+    def __init__(self, message="", status_code=None):
         super().__init__(message)
         self.status_code = status_code
 

--- a/v3io/dataplane/response.py
+++ b/v3io/dataplane/response.py
@@ -22,7 +22,7 @@ import v3io.dataplane.transport
 class HttpResponseError(Exception):
     """Exception raised on bad http status"""
 
-    def __init__(self, message, status_code):
+    def __init__(self, message='', status_code=None):
         super().__init__(message)
         self.status_code = status_code
 


### PR DESCRIPTION
In order to be able to raise the exception without parameters (like base Exception object), I added default parameters.

[ML-5598](https://jira.iguazeng.com/browse/ML-5598)