### PR TITLE
[Httpclient] fix pointer position of mmap object in the case of failure

### DIFF
--- a/tests/test_client_errors.py
+++ b/tests/test_client_errors.py
@@ -1,6 +1,7 @@
 import itertools
 import mmap
 import os
+import random
 import tempfile
 from http.client import CannotSendRequest
 
@@ -91,7 +92,7 @@ def test_first_connection_failure():
     )
     client._transport = mock_transport
     size = 1024
-    data = os.urandom(size)
+    data = random.Random(0).randbytes(size)
     with mmap.mmap(-1, size) as mmap_obj, tempfile.NamedTemporaryFile(mode="w+b", delete=False) as temp_file:
         mmap_obj.write(data)
         mmap_obj.seek(0)

--- a/tests/test_client_errors.py
+++ b/tests/test_client_errors.py
@@ -102,7 +102,7 @@ def test_first_connection_failure():
             container=container, path=path, body=mmap_obj, raise_for_status=v3io.dataplane.RaiseForStatus.never
         )
         temp_file.seek(0)
-        assert temp_file.read() == data
+        assert temp_file.read() == data, "Binary data read back differs from original data"
 
 
 def test_connection_creation_and_close():

--- a/v3io/dataplane/transport/httpclient.py
+++ b/v3io/dataplane/transport/httpclient.py
@@ -155,7 +155,7 @@ class Transport(abstract.Transport):
             "Tx", connection=connection, method=request.method, path=path, headers=request.headers, body=request.body
         )
         starting_offset = 0
-        if request.body is not None and hasattr(request.body, "seek") and hasattr(request.body, "tell"):
+        if request.body and hasattr(request.body, "seek") and hasattr(request.body, "tell"):
             starting_offset = request.body.tell()
         try:
             try:

--- a/v3io/dataplane/transport/httpclient.py
+++ b/v3io/dataplane/transport/httpclient.py
@@ -155,7 +155,8 @@ class Transport(abstract.Transport):
             "Tx", connection=connection, method=request.method, path=path, headers=request.headers, body=request.body
         )
         starting_offset = 0
-        if request.body and hasattr(request.body, "seek") and hasattr(request.body, "tell"):
+        is_body_seekable = request.body and hasattr(request.body, "seek") and hasattr(request.body, "tell")
+        if is_body_seekable:
             starting_offset = request.body.tell()
         try:
             try:
@@ -168,7 +169,7 @@ class Transport(abstract.Transport):
                     connection=connection,
                 )
                 connection.close()
-                if request.body and hasattr(request.body, "seek") and hasattr(request.body, "tell"):
+                if is_body_seekable:
                     # If the first connection fails, the pointer of the body might move at the size
                     # of the first connection blocksize.
                     # We need to reset the position of the pointer in order to send the whole file.


### PR DESCRIPTION
[ML-5926](https://iguazio.atlassian.net/browse/ML-5926)

When using an mmap object, this bug might occur:

If the first connection fails, the pointer still moves at the first attempt by the first connection's block size. After it fails, we try to create another connection and send data, but not from the beginning of the file.

This is why we might miss some bytes at the beginning of the file.


This PR solves the issue and explains it with comments.

[ML-5926]: https://iguazio.atlassian.net/browse/ML-5926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ