### PR TITLE
pin publish script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build binary wheel and source tarball
         run: make dist
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@release/v1.11
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
see failure: https://github.com/v3io/v3io-py/actions/runs/13901627710
following https://github.com/pypa/gh-action-pypi-publish/issues/300, trying to pin to 1.11