### PR TITLE
Remove use of `future` module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ all:
 .PHONY: fmt
 fmt:
 	@echo "Running black fmt..."
-	python -m black $(BLACK_OPTIONS) $(CHECKED_IN_PYTHON_FILES)
-	python -m isort $(ISORT_OPTIONS) $(CHECKED_IN_PYTHON_FILES)
+	@python -m black $(BLACK_OPTIONS) $(CHECKED_IN_PYTHON_FILES)
+	@python -m isort $(ISORT_OPTIONS) $(CHECKED_IN_PYTHON_FILES)
 
 .PHONY: lint
 lint: flake8 fmt-check
@@ -41,13 +41,13 @@ lint: flake8 fmt-check
 .PHONY: fmt-check
 fmt-check:
 	@echo "Running black+isort fmt check..."
-	python -m black $(BLACK_OPTIONS) --check --diff $(CHECKED_IN_PYTHON_FILES)
-	python -m isort --check --diff $(ISORT_OPTIONS) $(CHECKED_IN_PYTHON_FILES)
+	@python -m black $(BLACK_OPTIONS) --check --diff $(CHECKED_IN_PYTHON_FILES)
+	@python -m isort --check --diff $(ISORT_OPTIONS) $(CHECKED_IN_PYTHON_FILES)
 
 .PHONY: flake8
 flake8:
 	@echo "Running flake8 lint..."
-	python -m flake8 $(FLAKE8_OPTIONS) $(CHECKED_IN_PYTHON_FILES)
+	@python -m flake8 $(FLAKE8_OPTIONS) $(CHECKED_IN_PYTHON_FILES)
 
 .PHONY: clean_pyc
 clean_pyc:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,8 +20,6 @@ import time
 import unittest
 import unittest.mock
 
-import future.utils
-
 import v3io.common.helpers
 import v3io.dataplane
 import v3io.dataplane.output
@@ -340,7 +338,7 @@ class TestSchema(Test):
             "c": {"data_field_0": 3000, "data_field_1": 10000},
         }
 
-        for item_key, item_attributes in future.utils.viewitems(items):
+        for item_key, item_attributes in items.items():
             self._client.kv.put(
                 container=self._container, table_path=self._schema_dir, key=item_key, attributes=item_attributes
             )
@@ -460,7 +458,7 @@ class TestKv(Test):
             "tina": {"age": 14, "feature": "butts"},
         }
 
-        for item_key, item_attributes in future.utils.viewitems(items):
+        for item_key, item_attributes in items.items():
             self._client.kv.put(
                 container=self._container, table_path=self._path, key=item_key, attributes=item_attributes
             )
@@ -566,7 +564,7 @@ class TestKv(Test):
         }
 
         # put the item in a batch
-        for item_key, item_attributes in future.utils.viewitems(items):
+        for item_key, item_attributes in items.items():
             self._client.batch.kv.put(
                 container=self._container, table_path=self._path, key=item_key, attributes=item_attributes
             )
@@ -586,7 +584,7 @@ class TestKv(Test):
 
     def _delete_items(self, path, items):
         # delete items
-        for item_key, _ in future.utils.viewitems(items):
+        for item_key, _ in items.items():
             self._client.kv.delete(container=self._container, table_path=path, key=item_key)
 
         # delete dir
@@ -737,7 +735,7 @@ class TestConnectonErrorRecovery(Test):
         }
 
         # put the item in a batch
-        for item_key, item_attributes in future.utils.viewitems(items):
+        for item_key, item_attributes in items.items():
             self._client.batch.put_item(
                 container=self._container,
                 path=v3io.common.helpers.url_join(self._kv_path, item_key),

--- a/tests/test_client_aio.py
+++ b/tests/test_client_aio.py
@@ -17,8 +17,6 @@ import datetime
 import os
 import unittest
 
-import future.utils
-
 import v3io.aio.dataplane
 import v3io.dataplane
 
@@ -313,7 +311,7 @@ class TestObject(Test):
 #             "c": {"data_field_0": 3000, "data_field_1": 10000},
 #         }
 #
-#         for item_key, item_attributes in future.utils.viewitems(items):
+#         for item_key, item_attributes in items.items():
 #             await self._client.kv.put(
 #                 container=self._container, table_path=self._schema_dir, key=item_key, attributes=item_attributes
 #             )
@@ -428,7 +426,7 @@ class TestKv(Test):
             "tina": {"age": 14, "feature": "butts"},
         }
 
-        for item_key, item_attributes in future.utils.viewitems(items):
+        for item_key, item_attributes in items.items():
             await self._client.kv.put(
                 container=self._container, table_path=self._path, key=item_key, attributes=item_attributes
             )
@@ -529,7 +527,7 @@ class TestKv(Test):
 
     async def _delete_items(self, path, items):
         # delete items
-        for item_key, _ in future.utils.viewitems(items):
+        for item_key, _ in items.items():
             await self._client.kv.delete(container=self._container, table_path=path, key=item_key)
 
         # delete dir

--- a/v3io/dataplane/client.py
+++ b/v3io/dataplane/client.py
@@ -15,7 +15,6 @@
 import os
 import sys
 
-import future.utils
 import orjson
 
 import v3io.common.helpers
@@ -413,7 +412,7 @@ class Client(object):
         """
         responses = v3io.dataplane.response.Responses()
 
-        for item_path, item_attributes in future.utils.viewitems(items):
+        for item_path, item_attributes in items.items():
             # create a put item input
             response = self.put_item(
                 container,

--- a/v3io/dataplane/output.py
+++ b/v3io/dataplane/output.py
@@ -14,8 +14,6 @@
 #
 import base64
 
-import future.utils
-
 import v3io.dataplane.kv_array
 import v3io.dataplane.kv_timestamp
 
@@ -24,8 +22,8 @@ class Output(object):
     def _decode_typed_attributes(self, typed_attributes):
         decoded_attributes = {}
 
-        for attribute_key, typed_attribute_value in future.utils.viewitems(typed_attributes):
-            for attribute_type, attribute_value in future.utils.viewitems(typed_attribute_value):
+        for attribute_key, typed_attribute_value in typed_attributes.items():
+            for attribute_type, attribute_value in typed_attribute_value.items():
                 if attribute_type == "N":
                     try:
                         decoded_attribute = int(attribute_value)

--- a/v3io/dataplane/request.py
+++ b/v3io/dataplane/request.py
@@ -17,8 +17,6 @@ import base64
 import datetime
 import os
 
-import future.utils
-
 try:
     from urllib.parse import quote, urlencode
 except BaseException:
@@ -421,11 +419,11 @@ def _to_base64(input):
 def _dict_to_typed_attributes(d):
     typed_attributes = {}
     max_string_length = 61199
-    for key, value in future.utils.viewitems(d):
+    for key, value in d.items():
         attribute_type = type(value)
         type_value = None
 
-        if isinstance(value, future.utils.text_type):
+        if isinstance(value, str):
             type_key = "S"
             type_value = value
             if len(value) > max_string_length:
@@ -434,7 +432,7 @@ def _dict_to_typed_attributes(d):
                         key, len(value), max_string_length
                     )
                 )
-        elif isinstance(value, future.utils.string_types):
+        elif isinstance(value, str):
             type_key = "S"
             type_value = str(value)
             if len(type_value) > max_string_length:


### PR DESCRIPTION
This module was used to enable Python 2 support, which is no longer relevant.

[IG-24291](https://iguazio.atlassian.net/browse/IG-24291)

[IG-24291]: https://iguazio.atlassian.net/browse/IG-24291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ