### PR TITLE
Remove `future` from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 requests>=2.19.1
-future>=0.18.2
 orjson>=3.9.15, <4


### PR DESCRIPTION
Following removal of its use in #139.

[IG-24291](https://iguazio.atlassian.net/browse/IG-24291)

[IG-24291]: https://iguazio.atlassian.net/browse/IG-24291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ